### PR TITLE
Added examples tabs

### DIFF
--- a/src/gradio_app.py
+++ b/src/gradio_app.py
@@ -91,7 +91,7 @@ def choosistant(review_text):
         items=prediction.non_empty_drawbacks,
         bullet="😐",
         type_singular="drawback",
-        type_plural="drawback",
+        type_plural="drawbacks",
     )
 
     items = prediction.non_empty_benefits + prediction.non_empty_drawbacks
@@ -112,26 +112,47 @@ def choosistant(review_text):
 
 
 def main():
+    flagging_handler = FlaggingHandler()
     text_input = gr.Textbox(
         lines=8, placeholder="Enter the review text here...", label="Review Text"
     )
-    # new_title = gr.Textbox(label="Detected pro/con")
-    txt_pred_id = gr.Textbox(label="ID", visible=False)
-    txt_predictions = gr.HighlightedText(label="Predictions", combine_adjacent=True)
-    txt_predictions.style(color_map={"drawback": "red", "benefit": "green"})
-    example_url = "http://snap.stanford.edu/data/amazon/productGraph/categoryFiles/reviews_Musical_Instruments_5.json.gz"
-    iface = gr.Interface(
-        fn=choosistant,
-        inputs=[text_input],
-        outputs=[txt_predictions, txt_pred_id],
-        cache_examples=True,
-        description=f"Checkout some amazon reviews eg at [{example_url}]({example_url})",
-        allow_flagging="manual",
-        flagging_options=["Incorrect", "Offensive", "Other"],
-        flagging_dir="data/flagged",
-        flagging_callback=FlaggingHandler(),
-        examples=[["The top side came ripped off"], ["The gear is child friendly"]],
-    )
+
+    example_url = f"<a href='https://www.amazon.com/b?node=16225007011&pf_rd_r=SVC6K7QE0WNT3575Q2VJ&pf_rd_p=6b30eb15-a900-4294-9772-db8876444356&pd_rd_r=c2a147e6-37bf-41be-ba8b-826e1a45ad4c&pd_rd_w=3WOVP&pd_rd_wg=rWeT0&ref_=pd_gw_unk'>{'this page'}</a>"
+    with gr.Blocks() as iface:
+        gr.Markdown(f"Checkout some amazon reviews eg at {example_url}")
+        text_input = gr.Textbox(
+        lines=8,placeholder="Enter the review text here...",label="Review Text"
+        )
+        text_button = gr.Button('Submit')
+        txt_pred_id = gr.Textbox(label="ID", visible=False)
+        txt_predictions = gr.HighlightedText(label="Predictions", combine_adjacent=True)
+        txt_predictions.style(color_map={"drawback": "red", "benefit": "green"})
+        
+        text_button.click(choosistant, inputs=[text_input], outputs=[txt_predictions,txt_pred_id])
+        with gr.Row():
+            btn_incorrect = gr.Button("Flag as incorrect")
+            btn_insufficient = gr.Button("Flag as insufficient")
+            btn_other = gr.Button("Flag as other")
+        flagging_handler.setup(components=[text_input, txt_predictions,txt_pred_id], flagging_dir="data/flagged")
+
+
+        btn_incorrect.click(lambda *args:flagging_handler.flag(flag_data=args,flag_option='Incorrect'), [text_input,txt_predictions,txt_pred_id], None, preprocess=False)
+        btn_insufficient.click(lambda *args:flagging_handler.flag(flag_data=args, flag_option='Insufficient'), [text_input,txt_predictions,txt_pred_id], None, preprocess=False)
+        btn_other.click(lambda *args:flagging_handler.flag(flag_data=args, flag_option='Other'), [text_input,txt_predictions,txt_pred_id], None, preprocess=False)
+
+        with gr.Tab("Examples A"):
+            gr.Examples(examples =[
+            ["I purchased this harddrive to backup my other harddrives. It just crashed on me & I am currently on the phone trying about to be charged thousands of dollars to get data recovery on something I haven't even had for 6 months. DO NOT PURCHASE. Its cheap & faulty. Horrible quality and very sensitive. I did not drop it anywhere or damage it in any way. It just sat on my desk"],
+            ["Expensive, but I think it's the only legit Polar Express train set available, and the kids love Polar Express; what can you do?The track you get with the train makes a small oval shape, and is pretty easy to fit together. Slightly easier than Lego, but harder than Trackmaster stuff.The bell that comes with the train is really bad, we've had cat toys which resembled a bell better than this one, which is a real shame. It just kind of rattles around.The train itself is pretty well made, stays on the track, and can go forwards and backwards; as well as playing sound clips from the film, a nice chug chug sound, and steaming sound when it's stationary.Overall, giving it four stars. It's really expensive and the bell is awful, but the kids really love it"]
+            ],
+            inputs=[text_input],fn=choosistant,outputs=[txt_predictions,txt_pred_id], cache_examples=True,)
+        
+        with gr.Tab("Examples B"):
+            gr.Examples(examples=[
+            ['Not sure why I jumped on the bandwagon and got this. After seeing the price of the bottle of gel that you have to use with it, I knew I had been had. Now even that ~$25 bottle of gel is no longer available on Amazon -- its replacement is almost twice as expensive. Nuface says you cannot use Aloe Vera or anything else, you must use their product for the best results. Anyway, after using this ~1 month, I packed it away.Definitely do not recommend'],
+            ["Okay so FIRST the mounting process is a… PROCESS. the included template is helpful but the line in the middle of the template is NOT center.Be glad I saved you that headache.The other thing you need to know is the additional OEM frames are a bit of a nightmare. I was able to score the tv + frame for $999 together on Black Friday and I’m so glad I did because paying $150~ ish dollars for the plastic frames is really annoying when you discover that the poor packaging design means they arrive broken!! Go look at the reviews for the optional Samsung frames. If you’re patient and deal with the returns and reorder until it’s right it will work out but you’ve been warned okay?Alright all that aside the TV is gorgeous.\nI’m so happy with it. Picture quality is good my only complaint is that the screen should be more anti-reflective. It’s not as reflective as straight glass but with any lamps or windows you might be annoyed by the glare If you’re a design snob/observant enough in the first place to be looking at this tv. Regardless of the glare and the stupid overpriced bezels (which IMO are completely necessary if you want this tv since the whole point is to look like a frame) I would still repurchase because it’s just stunning to look at.Also the art subscription- just don’t.There’s not enough art to warrant $5 a month and you can upload your own pictures (of artwork that you can find on google for FREE) to the TV via the smart things app.They’ve shorted the free subscription to ONE month with a new tv purchase and it’s still not worth it. Just google your favorite art, save it in a high quality resolution and voilà."]
+           ],
+           inputs=[text_input],fn=choosistant,outputs=[txt_predictions,txt_pred_id], cache_examples=True)
 
     iface.launch(debug=True, server_port=8090)
 

--- a/src/gradio_app.py
+++ b/src/gradio_app.py
@@ -71,7 +71,7 @@ def convert_prediction_items_to_text(
     return result_text
 
 
-def choosistant(review_text):
+def choosistant(review_text, model_type):
     # Let the prediction service do its magic.
     prediction: Prediction = predict(review_text)
 
@@ -101,20 +101,30 @@ def main():
         text_input = gr.Textbox(
             lines=8, placeholder="Enter the review text here...", label="Review Text"
         )
+        model_input = gr.Radio(
+            choices=["QA", "SEQ2SEQ"],
+            label="Model Choice",
+            show_label=True,
+            interactive=True,
+            type="value",
+        )
+
         text_button = gr.Button("Submit")
         txt_pred_id = gr.Textbox(label="ID", visible=False)
         txt_predictions = gr.HighlightedText(label="Predictions", combine_adjacent=True)
         txt_predictions.style(color_map={"drawback": "red", "benefit": "green"})
 
         text_button.click(
-            choosistant, inputs=[text_input], outputs=[txt_predictions, txt_pred_id]
+            choosistant,
+            inputs=[text_input, model_input],
+            outputs=[txt_predictions, txt_pred_id],
         )
         with gr.Row():
             btn_incorrect = gr.Button("Flag as incorrect")
             btn_insufficient = gr.Button("Flag as insufficient")
             btn_other = gr.Button("Flag as other")
         flagging_handler.setup(
-            components=[text_input, txt_predictions, txt_pred_id],
+            components=[text_input, model_input, txt_predictions, txt_pred_id],
             flagging_dir="data/flagged",
         )
 
@@ -122,7 +132,7 @@ def main():
             lambda *args: flagging_handler.flag(
                 flag_data=args, flag_option="Incorrect"
             ),
-            [text_input, txt_predictions, txt_pred_id],
+            [text_input, model_input, txt_predictions, txt_pred_id],
             None,
             preprocess=False,
         )
@@ -130,13 +140,13 @@ def main():
             lambda *args: flagging_handler.flag(
                 flag_data=args, flag_option="Insufficient"
             ),
-            [text_input, txt_predictions, txt_pred_id],
+            [text_input, model_input, txt_predictions, txt_pred_id],
             None,
             preprocess=False,
         )
         btn_other.click(
             lambda *args: flagging_handler.flag(flag_data=args, flag_option="Other"),
-            [text_input, txt_predictions, txt_pred_id],
+            [text_input, model_input, txt_predictions, txt_pred_id],
             None,
             preprocess=False,
         )

--- a/src/gradio_app.py
+++ b/src/gradio_app.py
@@ -121,38 +121,79 @@ def main():
     with gr.Blocks() as iface:
         gr.Markdown(f"Checkout some amazon reviews eg at {example_url}")
         text_input = gr.Textbox(
-        lines=8,placeholder="Enter the review text here...",label="Review Text"
+            lines=8, placeholder="Enter the review text here...", label="Review Text"
         )
-        text_button = gr.Button('Submit')
+        text_button = gr.Button("Submit")
         txt_pred_id = gr.Textbox(label="ID", visible=False)
         txt_predictions = gr.HighlightedText(label="Predictions", combine_adjacent=True)
         txt_predictions.style(color_map={"drawback": "red", "benefit": "green"})
-        
-        text_button.click(choosistant, inputs=[text_input], outputs=[txt_predictions,txt_pred_id])
+
+        text_button.click(
+            choosistant, inputs=[text_input], outputs=[txt_predictions, txt_pred_id]
+        )
         with gr.Row():
             btn_incorrect = gr.Button("Flag as incorrect")
             btn_insufficient = gr.Button("Flag as insufficient")
             btn_other = gr.Button("Flag as other")
-        flagging_handler.setup(components=[text_input, txt_predictions,txt_pred_id], flagging_dir="data/flagged")
+        flagging_handler.setup(
+            components=[text_input, txt_predictions, txt_pred_id],
+            flagging_dir="data/flagged",
+        )
 
-
-        btn_incorrect.click(lambda *args:flagging_handler.flag(flag_data=args,flag_option='Incorrect'), [text_input,txt_predictions,txt_pred_id], None, preprocess=False)
-        btn_insufficient.click(lambda *args:flagging_handler.flag(flag_data=args, flag_option='Insufficient'), [text_input,txt_predictions,txt_pred_id], None, preprocess=False)
-        btn_other.click(lambda *args:flagging_handler.flag(flag_data=args, flag_option='Other'), [text_input,txt_predictions,txt_pred_id], None, preprocess=False)
+        btn_incorrect.click(
+            lambda *args: flagging_handler.flag(
+                flag_data=args, flag_option="Incorrect"
+            ),
+            [text_input, txt_predictions, txt_pred_id],
+            None,
+            preprocess=False,
+        )
+        btn_insufficient.click(
+            lambda *args: flagging_handler.flag(
+                flag_data=args, flag_option="Insufficient"
+            ),
+            [text_input, txt_predictions, txt_pred_id],
+            None,
+            preprocess=False,
+        )
+        btn_other.click(
+            lambda *args: flagging_handler.flag(flag_data=args, flag_option="Other"),
+            [text_input, txt_predictions, txt_pred_id],
+            None,
+            preprocess=False,
+        )
 
         with gr.Tab("Examples A"):
-            gr.Examples(examples =[
-            ["I purchased this harddrive to backup my other harddrives. It just crashed on me & I am currently on the phone trying about to be charged thousands of dollars to get data recovery on something I haven't even had for 6 months. DO NOT PURCHASE. Its cheap & faulty. Horrible quality and very sensitive. I did not drop it anywhere or damage it in any way. It just sat on my desk"],
-            ["Expensive, but I think it's the only legit Polar Express train set available, and the kids love Polar Express; what can you do?The track you get with the train makes a small oval shape, and is pretty easy to fit together. Slightly easier than Lego, but harder than Trackmaster stuff.The bell that comes with the train is really bad, we've had cat toys which resembled a bell better than this one, which is a real shame. It just kind of rattles around.The train itself is pretty well made, stays on the track, and can go forwards and backwards; as well as playing sound clips from the film, a nice chug chug sound, and steaming sound when it's stationary.Overall, giving it four stars. It's really expensive and the bell is awful, but the kids really love it"]
-            ],
-            inputs=[text_input],fn=choosistant,outputs=[txt_predictions,txt_pred_id], cache_examples=True,)
-        
+            gr.Examples(
+                examples=[
+                    [
+                        "I purchased this harddrive to backup my other harddrives. It just crashed on me & I am currently on the phone trying about to be charged thousands of dollars to get data recovery on something I haven't even had for 6 months. DO NOT PURCHASE. Its cheap & faulty. Horrible quality and very sensitive. I did not drop it anywhere or damage it in any way. It just sat on my desk"
+                    ],
+                    [
+                        "Expensive, but I think it's the only legit Polar Express train set available, and the kids love Polar Express; what can you do?The track you get with the train makes a small oval shape, and is pretty easy to fit together. Slightly easier than Lego, but harder than Trackmaster stuff.The bell that comes with the train is really bad, we've had cat toys which resembled a bell better than this one, which is a real shame. It just kind of rattles around.The train itself is pretty well made, stays on the track, and can go forwards and backwards; as well as playing sound clips from the film, a nice chug chug sound, and steaming sound when it's stationary.Overall, giving it four stars. It's really expensive and the bell is awful, but the kids really love it"
+                    ],
+                ],
+                inputs=[text_input],
+                fn=choosistant,
+                outputs=[txt_predictions, txt_pred_id],
+                cache_examples=True,
+            )
+
         with gr.Tab("Examples B"):
-            gr.Examples(examples=[
-            ['Not sure why I jumped on the bandwagon and got this. After seeing the price of the bottle of gel that you have to use with it, I knew I had been had. Now even that ~$25 bottle of gel is no longer available on Amazon -- its replacement is almost twice as expensive. Nuface says you cannot use Aloe Vera or anything else, you must use their product for the best results. Anyway, after using this ~1 month, I packed it away.Definitely do not recommend'],
-            ["Okay so FIRST the mounting process is a… PROCESS. the included template is helpful but the line in the middle of the template is NOT center.Be glad I saved you that headache.The other thing you need to know is the additional OEM frames are a bit of a nightmare. I was able to score the tv + frame for $999 together on Black Friday and I’m so glad I did because paying $150~ ish dollars for the plastic frames is really annoying when you discover that the poor packaging design means they arrive broken!! Go look at the reviews for the optional Samsung frames. If you’re patient and deal with the returns and reorder until it’s right it will work out but you’ve been warned okay?Alright all that aside the TV is gorgeous.\nI’m so happy with it. Picture quality is good my only complaint is that the screen should be more anti-reflective. It’s not as reflective as straight glass but with any lamps or windows you might be annoyed by the glare If you’re a design snob/observant enough in the first place to be looking at this tv. Regardless of the glare and the stupid overpriced bezels (which IMO are completely necessary if you want this tv since the whole point is to look like a frame) I would still repurchase because it’s just stunning to look at.Also the art subscription- just don’t.There’s not enough art to warrant $5 a month and you can upload your own pictures (of artwork that you can find on google for FREE) to the TV via the smart things app.They’ve shorted the free subscription to ONE month with a new tv purchase and it’s still not worth it. Just google your favorite art, save it in a high quality resolution and voilà."]
-           ],
-           inputs=[text_input],fn=choosistant,outputs=[txt_predictions,txt_pred_id], cache_examples=True)
+            gr.Examples(
+                examples=[
+                    [
+                        "Not sure why I jumped on the bandwagon and got this. After seeing the price of the bottle of gel that you have to use with it, I knew I had been had. Now even that ~$25 bottle of gel is no longer available on Amazon -- its replacement is almost twice as expensive. Nuface says you cannot use Aloe Vera or anything else, you must use their product for the best results. Anyway, after using this ~1 month, I packed it away.Definitely do not recommend"
+                    ],
+                    [
+                        "Okay so FIRST the mounting process is a… PROCESS. the included template is helpful but the line in the middle of the template is NOT center.Be glad I saved you that headache.The other thing you need to know is the additional OEM frames are a bit of a nightmare. I was able to score the tv + frame for $999 together on Black Friday and I’m so glad I did because paying $150~ ish dollars for the plastic frames is really annoying when you discover that the poor packaging design means they arrive broken!! Go look at the reviews for the optional Samsung frames. If you’re patient and deal with the returns and reorder until it’s right it will work out but you’ve been warned okay?Alright all that aside the TV is gorgeous.\nI’m so happy with it. Picture quality is good my only complaint is that the screen should be more anti-reflective. It’s not as reflective as straight glass but with any lamps or windows you might be annoyed by the glare If you’re a design snob/observant enough in the first place to be looking at this tv. Regardless of the glare and the stupid overpriced bezels (which IMO are completely necessary if you want this tv since the whole point is to look like a frame) I would still repurchase because it’s just stunning to look at.Also the art subscription- just don’t.There’s not enough art to warrant $5 a month and you can upload your own pictures (of artwork that you can find on google for FREE) to the TV via the smart things app.They’ve shorted the free subscription to ONE month with a new tv purchase and it’s still not worth it. Just google your favorite art, save it in a high quality resolution and voilà."
+                    ],
+                ],
+                inputs=[text_input],
+                fn=choosistant,
+                outputs=[txt_predictions, txt_pred_id],
+                cache_examples=True,
+            )
 
     iface.launch(debug=True, server_port=8090)
 

--- a/src/gradio_app.py
+++ b/src/gradio_app.py
@@ -75,25 +75,6 @@ def choosistant(review_text):
     # Let the prediction service do its magic.
     prediction: Prediction = predict(review_text)
 
-    # Convert the prediction to a text that can be displayed in the UI.
-    result_text = "Here is the result of prediction.\n\n"
-
-    result_text += convert_prediction_items_to_text(
-        items=prediction.non_empty_benefits,
-        bullet="😁",
-        type_singular="benefit",
-        type_plural="benefits",
-    )
-
-    result_text += "\n"
-
-    result_text += convert_prediction_items_to_text(
-        items=prediction.non_empty_drawbacks,
-        bullet="😐",
-        type_singular="drawback",
-        type_plural="drawbacks",
-    )
-
     items = prediction.non_empty_benefits + prediction.non_empty_drawbacks
     highlighted_entities = []
     for item in items:
@@ -108,16 +89,13 @@ def choosistant(review_text):
         "entities": highlighted_entities,
     }
 
-    return highlighted_input, 34123123
+    return highlighted_input, prediction.id
 
 
 def main():
     flagging_handler = FlaggingHandler()
-    text_input = gr.Textbox(
-        lines=8, placeholder="Enter the review text here...", label="Review Text"
-    )
 
-    example_url = f"<a href='https://www.amazon.com/b?node=16225007011&pf_rd_r=SVC6K7QE0WNT3575Q2VJ&pf_rd_p=6b30eb15-a900-4294-9772-db8876444356&pd_rd_r=c2a147e6-37bf-41be-ba8b-826e1a45ad4c&pd_rd_w=3WOVP&pd_rd_wg=rWeT0&ref_=pd_gw_unk'>{'this page'}</a>"
+    example_url = "<a href='https://www.amazon.com/b?node=16225007011&pf_rd_r=SVC6K7QE0WNT3575Q2VJ&pf_rd_p=6b30eb15-a900-4294-9772-db8876444356&pd_rd_r=c2a147e6-37bf-41be-ba8b-826e1a45ad4c&pd_rd_w=3WOVP&pd_rd_wg=rWeT0&ref_=pd_gw_unk'>this page</a>"  # noqa: E501
     with gr.Blocks() as iface:
         gr.Markdown(f"Checkout some amazon reviews eg at {example_url}")
         text_input = gr.Textbox(
@@ -167,10 +145,10 @@ def main():
             gr.Examples(
                 examples=[
                     [
-                        "I purchased this harddrive to backup my other harddrives. It just crashed on me & I am currently on the phone trying about to be charged thousands of dollars to get data recovery on something I haven't even had for 6 months. DO NOT PURCHASE. Its cheap & faulty. Horrible quality and very sensitive. I did not drop it anywhere or damage it in any way. It just sat on my desk"
+                        "I purchased this harddrive to backup my other harddrives. It just crashed on me & I am currently on the phone trying about to be charged thousands of dollars to get data recovery on something I haven't even had for 6 months. DO NOT PURCHASE. Its cheap & faulty. Horrible quality and very sensitive. I did not drop it anywhere or damage it in any way. It just sat on my desk"  # noqa: E501
                     ],
                     [
-                        "Expensive, but I think it's the only legit Polar Express train set available, and the kids love Polar Express; what can you do?The track you get with the train makes a small oval shape, and is pretty easy to fit together. Slightly easier than Lego, but harder than Trackmaster stuff.The bell that comes with the train is really bad, we've had cat toys which resembled a bell better than this one, which is a real shame. It just kind of rattles around.The train itself is pretty well made, stays on the track, and can go forwards and backwards; as well as playing sound clips from the film, a nice chug chug sound, and steaming sound when it's stationary.Overall, giving it four stars. It's really expensive and the bell is awful, but the kids really love it"
+                        "Expensive, but I think it's the only legit Polar Express train set available, and the kids love Polar Express; what can you do?The track you get with the train makes a small oval shape, and is pretty easy to fit together. Slightly easier than Lego, but harder than Trackmaster stuff.The bell that comes with the train is really bad, we've had cat toys which resembled a bell better than this one, which is a real shame. It just kind of rattles around.The train itself is pretty well made, stays on the track, and can go forwards and backwards; as well as playing sound clips from the film, a nice chug chug sound, and steaming sound when it's stationary.Overall, giving it four stars. It's really expensive and the bell is awful, but the kids really love it"  # noqa: E501
                     ],
                 ],
                 inputs=[text_input],
@@ -183,10 +161,10 @@ def main():
             gr.Examples(
                 examples=[
                     [
-                        "Not sure why I jumped on the bandwagon and got this. After seeing the price of the bottle of gel that you have to use with it, I knew I had been had. Now even that ~$25 bottle of gel is no longer available on Amazon -- its replacement is almost twice as expensive. Nuface says you cannot use Aloe Vera or anything else, you must use their product for the best results. Anyway, after using this ~1 month, I packed it away.Definitely do not recommend"
+                        "Not sure why I jumped on the bandwagon and got this. After seeing the price of the bottle of gel that you have to use with it, I knew I had been had. Now even that ~$25 bottle of gel is no longer available on Amazon -- its replacement is almost twice as expensive. Nuface says you cannot use Aloe Vera or anything else, you must use their product for the best results. Anyway, after using this ~1 month, I packed it away.Definitely do not recommend"  # noqa: E501
                     ],
                     [
-                        "Okay so FIRST the mounting process is a… PROCESS. the included template is helpful but the line in the middle of the template is NOT center.Be glad I saved you that headache.The other thing you need to know is the additional OEM frames are a bit of a nightmare. I was able to score the tv + frame for $999 together on Black Friday and I’m so glad I did because paying $150~ ish dollars for the plastic frames is really annoying when you discover that the poor packaging design means they arrive broken!! Go look at the reviews for the optional Samsung frames. If you’re patient and deal with the returns and reorder until it’s right it will work out but you’ve been warned okay?Alright all that aside the TV is gorgeous.\nI’m so happy with it. Picture quality is good my only complaint is that the screen should be more anti-reflective. It’s not as reflective as straight glass but with any lamps or windows you might be annoyed by the glare If you’re a design snob/observant enough in the first place to be looking at this tv. Regardless of the glare and the stupid overpriced bezels (which IMO are completely necessary if you want this tv since the whole point is to look like a frame) I would still repurchase because it’s just stunning to look at.Also the art subscription- just don’t.There’s not enough art to warrant $5 a month and you can upload your own pictures (of artwork that you can find on google for FREE) to the TV via the smart things app.They’ve shorted the free subscription to ONE month with a new tv purchase and it’s still not worth it. Just google your favorite art, save it in a high quality resolution and voilà."
+                        "Okay so FIRST the mounting process is a… PROCESS. the included template is helpful but the line in the middle of the template is NOT center.Be glad I saved you that headache.The other thing you need to know is the additional OEM frames are a bit of a nightmare. I was able to score the tv + frame for $999 together on Black Friday and I’m so glad I did because paying $150~ ish dollars for the plastic frames is really annoying when you discover that the poor packaging design means they arrive broken!! Go look at the reviews for the optional Samsung frames. If you’re patient and deal with the returns and reorder until it’s right it will work out but you’ve been warned okay?Alright all that aside the TV is gorgeous.\nI’m so happy with it. Picture quality is good my only complaint is that the screen should be more anti-reflective. It’s not as reflective as straight glass but with any lamps or windows you might be annoyed by the glare If you’re a design snob/observant enough in the first place to be looking at this tv. Regardless of the glare and the stupid overpriced bezels (which IMO are completely necessary if you want this tv since the whole point is to look like a frame) I would still repurchase because it’s just stunning to look at.Also the art subscription- just don’t.There’s not enough art to warrant $5 a month and you can upload your own pictures (of artwork that you can find on google for FREE) to the TV via the smart things app.They’ve shorted the free subscription to ONE month with a new tv purchase and it’s still not worth it. Just google your favorite art, save it in a high quality resolution and voilà."  # noqa: E501
                     ],
                 ],
                 inputs=[text_input],

--- a/src/prediction_service.py
+++ b/src/prediction_service.py
@@ -79,3 +79,6 @@ def predict(review_text) -> Prediction:
         labels=result["labels"],
         scores=result["scores"],
     )
+
+if __name__=="__main__":
+    predict("I love this as it doesn't really have a scent and it's very lightweight. It doesn't make my skin oily and personally helps clear my acne faster sometimes. I have gifted it a few times and they loved it.")

--- a/src/prediction_service.py
+++ b/src/prediction_service.py
@@ -74,6 +74,7 @@ def predict(review_text) -> Prediction:
     payload = {
         "url": "https://localhost/",
         "review_text": review_text,
+        # "model_type": 'qa','seq2seq'
     }
     resp = requests.post(url=API_SERVER_URL, json=payload)
     if resp.status_code != 200:

--- a/src/prediction_service.py
+++ b/src/prediction_service.py
@@ -80,5 +80,8 @@ def predict(review_text) -> Prediction:
         scores=result["scores"],
     )
 
-if __name__=="__main__":
-    predict("I love this as it doesn't really have a scent and it's very lightweight. It doesn't make my skin oily and personally helps clear my acne faster sometimes. I have gifted it a few times and they loved it.")
+
+if __name__ == "__main__":
+    predict(
+        "I love this as it doesn't really have a scent and it's very lightweight. It doesn't make my skin oily and personally helps clear my acne faster sometimes. I have gifted it a few times and they loved it."
+    )

--- a/src/prediction_service.py
+++ b/src/prediction_service.py
@@ -20,10 +20,11 @@ class PredictionItem:
 
 class Prediction:
     def __init__(
-        self, segments: List[str], labels: List[str], scores: List[float]
+        self, segments: List[str], labels: List[str], scores: List[float], id: str
     ) -> None:
         self._benefits = []
         self._drawbacks = []
+        self._id = id
 
         for segment, label, score in zip(segments, labels, scores):
             item = PredictionItem(label=label, text=segment, score=score)
@@ -51,6 +52,10 @@ class Prediction:
     def non_empty_drawbacks(self) -> List[PredictionItem]:
         return self._filter_items(self._drawbacks)
 
+    @property
+    def id(self) -> str:
+        return self._id
+
     def _filter_items(self, items: List[PredictionItem]) -> List[PredictionItem]:
         non_empty_items = [item for item in items if item.text.strip() != ""]
         sorted_items = sorted(
@@ -74,14 +79,10 @@ def predict(review_text) -> Prediction:
     if resp.status_code != 200:
         return "Error"
     result = resp.json()
+
     return Prediction(
         segments=result["segments"],
         labels=result["labels"],
         scores=result["scores"],
-    )
-
-
-if __name__ == "__main__":
-    predict(
-        "I love this as it doesn't really have a scent and it's very lightweight. It doesn't make my skin oily and personally helps clear my acne faster sometimes. I have gifted it a few times and they loved it."
+        id=result["id"],
     )


### PR DESCRIPTION
I had to switch to gradio blocks to allow for use of examples as illustrated in the pushed code.
I have run it and all the previous functionalities(including flagging) work.

I also noticed that the text_prediction_id that is flagged is the same for all predictions. Perhaps we might need to polish that...?